### PR TITLE
Fixed broken example

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Mounted routes may contain slugs and can be restricted to a certain HTTP method:
 
 ```ruby
 app = Shelf::Builder.app do
-  map('/users/{id}', :GET) { run ->(env) { [200, { ... }, [env['shelf.request.query_hash'][:id]]] } }
+  get('/users/{id}') { run ->(env) { [200, { ... }, [env['shelf.request.query_hash'][:id]]] } }
 end
 
 app.call('REQUEST_METHOD' => 'GET', 'PATH_INFO' => '/users/1')


### PR DESCRIPTION
If we pass Symbol as `map`'s second argument, we get following exception.

```
can't convert Symbol to Integer (TypeError)
```

It seems that we cannot use Symbol, and should use Integer (maybe we could in the past?).

- https://github.com/katzer/mruby-shelf/blob/master/mrblib/shelf/builder.rb#L159
- https://github.com/katzer/mruby-r3/blob/master/mrblib/r3.rb#L46

So I fixed the example to use `get` method, instead of using `map` .