### PR TITLE
Search action using method argument

### DIFF
--- a/mrblib/shelf/dispatcher.rb
+++ b/mrblib/shelf/dispatcher.rb
@@ -47,8 +47,8 @@ module Shelf
 
       params, (app, data) = @tree.match(path, method)
 
-      return path_not_found     unless params
-      return method_not_allowed if @tree.mismatch? path, method
+      return method_not_allowed if !params && @tree.match?(path)
+      return path_not_found unless params
 
       store_query_hash_into_env(params, env)
       env[SHELF_R3_DATA] = data if data

--- a/mrblib/shelf/dispatcher.rb
+++ b/mrblib/shelf/dispatcher.rb
@@ -44,7 +44,7 @@ module Shelf
       path   = env[PATH_INFO]
       method = R3.method_code(env[REQUEST_METHOD])
 
-      params, (app, data) = @tree.match(path)
+      params, (app, data) = @tree.match(path, method)
 
       return path_not_found     unless params
       return method_not_allowed if @tree.mismatch? path, method

--- a/mrblib/shelf/dispatcher.rb
+++ b/mrblib/shelf/dispatcher.rb
@@ -43,6 +43,7 @@ module Shelf
     def call(env)
       path   = env[PATH_INFO]
       method = R3.method_code(env[REQUEST_METHOD])
+      raise ArgumentError, "Invalid HTTP method: #{env[REQUEST_METHOD].inspect}." unless method
 
       params, (app, data) = @tree.match(path, method)
 

--- a/mrblib/shelf/dispatcher.rb
+++ b/mrblib/shelf/dispatcher.rb
@@ -43,7 +43,7 @@ module Shelf
     def call(env)
       path   = env[PATH_INFO]
       method = R3.method_code(env[REQUEST_METHOD])
-      raise ArgumentError, "Invalid HTTP method: #{env[REQUEST_METHOD].inspect}." unless method
+      return method_not_allowed unless method
 
       params, (app, data) = @tree.match(path, method)
 

--- a/test/builder.rb
+++ b/test/builder.rb
@@ -161,3 +161,15 @@ assert 'Shelf::Builder.call', 'with slugs' do
 
   assert_equal ['1'], app.call(env_for('/users/1'))[2]
 end
+
+assert 'Shelf::Builder.call', 'Invalid HTTP method' do
+  app = Shelf::Builder.new do
+    get('/users') do
+      run ->(env) { [200, {}, ['ok']] }
+    end
+  end
+
+  assert_raise_with_message(ArgumentError, 'Invalid HTTP method: "INVALID".') do
+    app.call(env_for('/users', method: 'INVALID'))[2]
+  end
+end

--- a/test/builder.rb
+++ b/test/builder.rb
@@ -139,7 +139,7 @@ assert 'Shelf::Builder.call', 'restrict request method' do
   assert_equal 200, app.call(env_for('/any', method: 'PUT'))[0]
   assert_equal 200, app.call(env_for('/any', method: 'GET'))[0]
   assert_equal 200, app.call(env_for('/put', method: 'PUT'))[0]
-  assert_equal 404, app.call(env_for('/put', method: 'GET'))[0]
+  assert_equal 405, app.call(env_for('/put', method: 'GET'))[0]
 end
 
 assert 'Shelf::Builder.call', 'same path, other method' do

--- a/test/builder.rb
+++ b/test/builder.rb
@@ -139,7 +139,17 @@ assert 'Shelf::Builder.call', 'restrict request method' do
   assert_equal 200, app.call(env_for('/any', method: 'PUT'))[0]
   assert_equal 200, app.call(env_for('/any', method: 'GET'))[0]
   assert_equal 200, app.call(env_for('/put', method: 'PUT'))[0]
-  assert_equal 405, app.call(env_for('/put', method: 'GET'))[0]
+  assert_equal 404, app.call(env_for('/put', method: 'GET'))[0]
+end
+
+assert 'Shelf::Builder.call', 'same path, other method' do
+  app = Shelf::Builder.app do
+    get('/hoge') { run ->(_) { [200, {}, ['OK get']] } }
+    put('/hoge') { run ->(_) { [200, {}, ['OK put']] } }
+  end
+
+  assert_equal ['OK get'], app.call(env_for('/hoge', method: 'GET'))[2]
+  assert_equal ['OK put'], app.call(env_for('/hoge', method: 'PUT'))[2]
 end
 
 assert 'Shelf::Builder.call', 'with slugs' do

--- a/test/builder.rb
+++ b/test/builder.rb
@@ -169,7 +169,5 @@ assert 'Shelf::Builder.call', 'Invalid HTTP method' do
     end
   end
 
-  assert_raise_with_message(ArgumentError, 'Invalid HTTP method: "INVALID".') do
-    app.call(env_for('/users', method: 'INVALID'))[2]
-  end
+  assert_equal(405, app.call(env_for('/users', method: 'INVALID'))[0])
 end


### PR DESCRIPTION
If we define two actions with the same path but a different method, requests pointing to the path result in unintuitive behavior:

- What we expect: action with the same path and the same method is executed
- What happens: action with the same path but **different method** is executed
  - Sometimes, the desired action might be executed

This is because, in dispatching requests, Shelf's current implementation does not pass `method` to `R3::Tree#match`.

In order to fix this issue, I modified Dispatcher to use `method` in addition to `path` to match `@tree`.